### PR TITLE
Update dependencies and reduce panic calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ default = ["wee_alloc"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [dependencies]
-wasm-bindgen = "0.2.63"
-twox-hash = { version = "1.6.0" }
+wasm-bindgen = "0.2.83"
+twox-hash = { version = "1.6" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -31,7 +31,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.13"
+wasm-bindgen-test = "0.3.33"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = ["wee_alloc"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = "0.2.83"
 twox-hash = { version = "1.6" }
 

--- a/src/hash128.rs
+++ b/src/hash128.rs
@@ -1,6 +1,5 @@
 use super::utils;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsValue;
 use twox_hash::Xxh3Hash128;
 use std::hash::Hasher;
 use twox_hash::xxh3::HasherExt;
@@ -20,7 +19,7 @@ impl Hash128 {
 		}
 	}
 
-	pub fn hash_string(&self, data: String, seed: JsValue) -> String {
+	pub fn hash_string(&self, data: String, seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -28,16 +27,16 @@ impl Hash128 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u64,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = Xxh3Hash128::with_seed(seed_val);
 		}
 
 		hasher.write(data.as_bytes());
-		format!("{:x}", hasher.finish_ext())
+		Ok(format!("{:x}", hasher.finish_ext()))
 	}
 
-	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> String {
+	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -45,13 +44,13 @@ impl Hash128 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u64,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = Xxh3Hash128::with_seed(seed_val);
 		}
 
 		hasher.write(data);
-		format!("{:x}", hasher.finish_ext())
+		Ok(format!("{:x}", hasher.finish_ext()))
 	}
 
 	pub fn init(&mut self, seed: u64) {

--- a/src/hash32.rs
+++ b/src/hash32.rs
@@ -1,6 +1,5 @@
 use super::utils;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsValue;
 use twox_hash::XxHash32;
 use std::hash::Hasher;
 
@@ -19,7 +18,7 @@ impl Hash32 {
 		}
 	}
 
-	pub fn hash_string(&self, data: String, seed: JsValue) -> String {
+	pub fn hash_string(&self, data: String, seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -27,17 +26,18 @@ impl Hash32 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u32,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = XxHash32::with_seed(seed_val);
 		}
 
 		hasher.write(data.as_bytes());
 		let result = hasher.finish();
-		format!("{:x}", result)
+
+		Ok(format!("{:x}", result))
 	}
 
-	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> String {
+	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -45,14 +45,15 @@ impl Hash32 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u32,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = XxHash32::with_seed(seed_val);
 		}
 
 		hasher.write(data);
 		let result =  hasher.finish();
-		format!("{:x}", result)
+
+		Ok(format!("{:x}", result))
 	}
 
 	pub fn init(&mut self, seed: u32) {

--- a/src/hash64.rs
+++ b/src/hash64.rs
@@ -1,6 +1,5 @@
 use super::utils;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsValue;
 use twox_hash::XxHash64;
 use std::hash::Hasher;
 
@@ -19,7 +18,7 @@ impl Hash64 {
 		}
 	}
 
-	pub fn hash_string(&self, data: String, seed: JsValue) -> String {
+	pub fn hash_string(&self, data: String, seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -27,16 +26,16 @@ impl Hash64 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u64,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = XxHash64::with_seed(seed_val);
 		}
 
 		hasher.write(data.as_bytes());
-		format!("{:x}", hasher.finish())
+		Ok(format!("{:x}", hasher.finish()))
 	}
 
-	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> String {
+	pub fn hash_bytes(&self, data: &[u8], seed: JsValue) -> Result<String, JsError> {
 		let mut hasher;
 
 		if seed.is_undefined() {
@@ -44,13 +43,13 @@ impl Hash64 {
 		} else {
 			let seed_val = match seed.as_f64() {
 				Some(x) => x as u64,
-				None => panic!("Seed must be a number"),
+				None => return Err(JsError::new("Seed must be a number")),
 			};
 			hasher = XxHash64::with_seed(seed_val);
 		}
 
 		hasher.write(data);
-		format!("{:x}", hasher.finish())
+		Ok(format!("{:x}", hasher.finish()))
 	}
 
 	pub fn init(&mut self, seed: u64) {


### PR DESCRIPTION
Seems wasm-bindgen knows how to send a `Result` type back to JS land so I cut a little PR for that. 